### PR TITLE
Fix missing default subheading inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,11 @@
     const addBtn = document.getElementById('add-subheading');
     let subheadingCount = 3;
 
+    // create default subheading fields on load
+    for (let i = 0; i < subheadingCount; i++) {
+      subheadingsContainer.appendChild(createSubheadingInput(i));
+    }
+
     function createSubheadingInput(index) {
       const div = document.createElement('div');
       div.classList.add('subheading');


### PR DESCRIPTION
## Summary
- add missing default subheading fields on page load

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68682a28a0908325a477417401c842b7